### PR TITLE
Prevent Flags::StartGo value truncate on 32bit systems because it overflow default isize enum repr

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,3 +1,4 @@
+#[repr(usize)]
 #[derive(Debug)]
 pub enum Flags {
     Checkered = 0x00000001,


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#enum_clike_unportable_variant